### PR TITLE
Added 'usingEditLabel' method

### DIFF
--- a/src/SelectPlus.php
+++ b/src/SelectPlus.php
@@ -21,6 +21,7 @@ class SelectPlus extends Field
 
     public $indexLabel = null;
     public $detailLabel = null;
+    public $editLabel = null;
 
     public $valueForIndexDisplay = null;
     public $valueForDetailDisplay = null;
@@ -67,6 +68,17 @@ class SelectPlus extends Field
     public function usingDetailLabel($detailLabel)
     {
         $this->detailLabel = $detailLabel;
+
+        return $this;
+    }
+
+    /**
+     * @param string|callable $editLabel
+     * @return $this
+     */
+    public function usingEditLabel($editLabel)
+    {
+        $this->editLabel = $editLabel;
 
         return $this;
     }
@@ -183,7 +195,7 @@ class SelectPlus extends Field
             // todo add order field
             return [
                 $model->getKeyName() => $model->getKey(),
-                'label' => $model->{$this->label}
+                'label' => $this->getEditLabel($model)
             ];
         });
     }
@@ -199,6 +211,19 @@ class SelectPlus extends Field
             'max_selections'           => $this->maxSelections,
             'reorderable'              => $this->reorderable !== null
         ]);
+    }
+
+    protected function getEditLabel($model)
+    {
+        if (is_callable($this->editLabel)) {
+            return call_user_func($this->editLabel, $model, $this->label);
+        }
+
+        if (is_string($this->editLabel)) {
+            return $model->{$this->editLabel};
+        }
+
+        return $model->{$this->label};
     }
 }
 


### PR DESCRIPTION
Hello,

Much like `usingIndexLabel` and `usingDetailLabel`, this allows to customize the label on the edit screen.
For example:
```
SelectPlus::make('States Lived In', 'statesLivedIn', State::class)
  ->label('name')
  ->usingEditLabel(function ($model, $label) {
    return "{$model->nicePrefixAttribute}:{$model->$label}";
  });
```
Fixes #6