### PR TITLE
feature - dusk attribute for e2e testing

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -6,6 +6,7 @@
           class="nova-select-plus-vs"
           v-model:value="selected"
           v-bind:options="options"
+          v-bind:dusk="field.attribute"
           v-bind:loading="isLoading"
           v-bind:disabled="field.readonly"
           v-bind:multiple="true"


### PR DESCRIPTION
# What

This enables the field to be in line with other Laravel Fields such as the TextField (resources/js/components/Form/TextField.vue) by adding a dusk attribute.

![2020-09-28_21-32](https://user-images.githubusercontent.com/312003/94478311-65a56f00-01d3-11eb-805d-f484c68ef5c1.png)

From the parent you can now easily target any child element.

