### PR TITLE
Nova Select Plus on Panels and Other Controls

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -19,12 +19,25 @@ class Controller
 
     public function options(NovaRequest $request, $resource, $relationship)
     {
+        $availableFields = $request->newResource()
+            ->availableFields($request);
+
         /** @var SelectPlus $field */
-        $field = $request->newResource()
-            ->availableFields($request)
+        $field = $availableFields
             ->where('component', 'select-plus')
             ->where('attribute', $relationship)
             ->first();
+
+        //Look a little harder - It may be on another control.
+        if (!$field) {
+            $field = $availableFields->pluck('meta.fields')
+                ->whereNotNull()
+                ->flatten()
+                ->where('component', 'select-plus')
+                ->where('attribute', $relationship)
+                ->first();
+        }
+        
 
         /** @var Builder $model */
         $query = $field->relationshipResource::newModel()->newQuery();


### PR DESCRIPTION
# Details
Fixes Nova-Select-Plus when it is on another control.  Specifically tested with nova-dependency-container

# Prerequisites
1. Build a small nova application, with at least one model.
1. Add a Nova Dependency Panel (epartment/nova-dependency-container) to the form and make it dependent on another property of the model.
1. Add a Nova Select Plus component to the panel.

# Steps to test changes
1. In the application, select the control to make the container show.
1. _Observe_ that the Select-Plus component renders and the options are available.

# Issues Addressed
#25 Addresses issue where it cannot be found on another panel/component.