### PR TITLE
Support Nova 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/nova": "^4.0"
+        "laravel/nova": "^4.0|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "baberuth22/nova-select-plus",
+    "name": "ziffmedia/nova-select-plus",
     "description": "A Nova select field for simple and complex select inputs",
     "type": "library",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ziffmedia/nova-select-plus",
+    "name": "baberuth22/nova-select-plus",
     "description": "A Nova select field for simple and complex select inputs",
     "type": "library",
     "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,8 @@ composer require ziffmedia/nova-select-plus
 ## Versions &amp; Compatibility
 
 - Version `^1.0` supports Nova 2-3
-- Version `^2.0` supports Nova 4-5 (with Vue 3, dark mode support, etc)
+- Version `^2.0` supports Nova 4 (with Vue 3, dark mode support, etc)
+- Version `^2.1` supports Nova 5
 
 ## Description &amp; Use Cases
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ composer require ziffmedia/nova-select-plus
 ## Versions &amp; Compatibility
 
 - Version `^1.0` supports Nova 2-3
-- Version `^2.0` supports Nova 4 (with Vue 3, dark mode support, etc)
+- Version `^2.0` supports Nova 4-5 (with Vue 3, dark mode support, etc)
 
 ## Description &amp; Use Cases
 

--- a/src/SelectPlus.php
+++ b/src/SelectPlus.php
@@ -140,7 +140,7 @@ class SelectPlus extends Field
      * @param  mixed|resource|Model  $resource
      * @param  null  $attribute
      */
-    public function resolve($resource, ?string $attribute = null):void
+    public function resolve($resource, $attribute = null): void
     {
         $attribute = $this->attribute;
 

--- a/src/SelectPlus.php
+++ b/src/SelectPlus.php
@@ -140,7 +140,7 @@ class SelectPlus extends Field
      * @param  mixed|resource|Model  $resource
      * @param  null  $attribute
      */
-    public function resolve($resource, $attribute = null): void
+    public function resolve($resource, ?string $attribute = null):void
     {
         $attribute = $this->attribute;
 


### PR DESCRIPTION
Fixes #73 

Adds support for Nova v5.0 by reimplementing a PR from @baberuth22 which had some accidental changes. I'm testing this on the www.protect.earth Tree Tracker currently. 