### PR TITLE
Use loadMissing to avoid n+1 if relationship already loaded

### DIFF
--- a/src/SelectPlus.php
+++ b/src/SelectPlus.php
@@ -159,7 +159,7 @@ class SelectPlus extends Field
 
         // use base functionality to populate $this->value, load in case Lazy Loading is disabled
         if (method_exists($resource, $attribute)) {
-            $resource->load($attribute);
+            $resource->loadMissing($attribute);
         }
 
         parent::resolve($resource, $attribute);


### PR DESCRIPTION
Currently the `->load` call on the resource results in a forced n+1 query result. 

Before:
![image](https://github.com/user-attachments/assets/c28d1fb0-83c2-4ee4-9bbb-a8561408ade2)

After:
![image](https://github.com/user-attachments/assets/37c1d56d-aec6-4e77-8c21-fb3e8a539649)
